### PR TITLE
Fix error template (bug 938525)

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -10,13 +10,13 @@ function formatHTML(req, res, body) {
   if (body instanceof Error) {
     res.statusCode = body.statusCode || 500;
     body = body.message;
-    body = z.env.render('error.html', {
-      title: 'Error',
-      content: body,
-    });
 
-    if (res.docName !== undefined) {
-      body = z.markSafe(body);
+    // If there's no doc then make this a full-page error.
+    if (res.docName === undefined) {
+      body = z.env.render('error.html', {
+        title: 'Error',
+        content: body,
+      });
     }
 
   } else if (typeof (body) === 'object') {

--- a/media/stylus/zippy.styl
+++ b/media/stylus/zippy.styl
@@ -9,7 +9,7 @@
 @import '_full-error';
 
 html, body {
-    background: #fff;
+    background: $bg-color;
     height: 100%;
     margin: 0;
     font-family: "Fira Sans","Open Sans","Helvetica Neue",Arial,sans-serif;

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,1 +1,15 @@
-{{ content }}
+{% extends "base.html" %}
+
+{% block bodyattrs %} class="error"{% endblock %}
+{% block title %}{{ title }}{% endblock %}
+
+{% block style %}
+<link rel="stylesheet" href="/css/zippy.css">
+{% endblock %}
+
+{% block main %}
+  <h1>{% if code %}{{ code }}{% else %}Oops…{% endif %}</h1>
+  <div class="msg">
+    <p>{{ content }}</p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Fixes the way templates are used for errors so the templating isn't used in the dynamic docs.
