### PR TITLE
Get rid of id/uuid ambiguity for sellers/products (bug 942222)

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -6,6 +6,8 @@ Developers
 This covers registering setting up a seller (who is normally an app developer)
 and registering their products with the payment provider.
 
+Note that in the following examples ``{*uuid}`` refers to an actual ``uuid``.
+
 .. _sellers:
 
 Sellers
@@ -28,13 +30,12 @@ pertinent to developer payouts.
 
         [
           {
-            "uuid": "...",
             "status": "ACTIVE",
             "name": "John",
             "email": "jdoe@example.org",
-            "resource_pk": "1",
+            "resource_pk": "{seller-uuid}",
             "resource_name": "sellers",
-            "resource_uri": "/sellers/1",
+            "resource_uri": "/sellers/{seller-uuid}",
             "agreement": ""
           },
           ...
@@ -51,13 +52,12 @@ pertinent to developer payouts.
     .. code-block:: json
 
         {
-          "uuid": "...",
           "status": "ACTIVE",
           "name": "John",
           "email": "jdoe@example.org",
-          "resource_pk": "1",
+          "resource_pk": "{seller-uuid}",
           "resource_name": "sellers",
-          "resource_uri": "/sellers/1",
+          "resource_uri": "/sellers/{seller-uuid}",
           "agreement": ""
         }
 
@@ -99,13 +99,12 @@ pertinent to developer payouts.
     .. code-block:: json
 
         {
-          "uuid": "...",
           "status": "ACTIVE",
           "name": "John",
           "email": "jdoe@example.org",
-          "resource_pk": "1",
+          "resource_pk": "{seller-uuid}",
           "resource_name": "sellers",
-          "resource_uri": "/sellers/1",
+          "resource_uri": "/sellers/{seller-uuid}",
           "agreement": ""
         }
 
@@ -162,13 +161,8 @@ provider.
         seller is probably a good idea.
 
     :param seller_id:
-        Filter all products by this seller ID, the
-        primary key for the :ref:`seller <sellers>` who owns each product.
-
-    :param seller_uuid:
         Filter all products by this seller UUID, the
-        unique identifier for the :ref:`seller <sellers>` who owns each
-        product.
+        primary key for the :ref:`seller <sellers>` who owns each product.
 
     **Response**
 
@@ -178,13 +172,13 @@ provider.
 
         [
           {
-            "external_id": "...",
-            "seller_id": ...,
+            "external_id": "{product-uuid}",
+            "seller_id": "{seller-uuid}",
             "active": true,
             "name": "Magical Unicorn",
-            "resource_pk": "1",
+            "resource_pk": "{product-uuid}",
             "resource_name": "products",
-            "resource_uri": "/products/1"
+            "resource_uri": "/products/{product-uuid}"
           }, {
           ...
           }
@@ -225,13 +219,13 @@ provider.
     .. code-block:: json
 
         {
-          "external_id": "...",
-          "seller_id": ...,
+          "external_id": "{product-uuid}",
+          "seller_id": "{seller-uuid}",
           "active": true,
           "name": "Magical Unicorn",
-          "resource_pk": "1",
+          "resource_pk": "{product-uuid}",
           "resource_name": "products",
-          "resource_uri": "/products/1"
+          "resource_uri": "/products/{product-uuid}"
         }
 
     In case of an error:
@@ -242,7 +236,7 @@ provider.
           "code": "InvalidArgument",
           "message": {
             "external_id": "external_id must be unique",
-            "seller_id":"zero results for seller_id 2"
+            "seller_id":"zero results for seller_id {wrong-uuid}"
           }
         }
 

--- a/lib/products.js
+++ b/lib/products.js
@@ -14,9 +14,6 @@ var listProductsForm = forms.create({
   external_id: fields.string({
     required: false,
   }),
-  seller_uuid: fields.string({
-    required: false,
-  }),
   seller_id: fields.string({
     required: false,
   }),
@@ -34,16 +31,15 @@ exports.list = function(req, res, next) {
           query[k] = data[k];
         }
       });
-      if (query.seller_uuid) {
-        return Q.ninvoke(sellers.models, 'findOne', {uuid: query.seller_uuid})
+      if (query.seller_id) {
+        return Q.ninvoke(sellers.models, 'findOne', {_id: query.seller_id})
           .then(function(seller) {
             if (!seller) {
               throw new restify.NotFoundError({
-                message: 'seller with UUID ' + query.seller_uuid + ' not found'
+                message: 'seller with UUID ' + query.seller_id + ' not found'
               });
             }
             query.seller_id = seller._id;
-            delete query.seller_uuid;
           });
       }
     })

--- a/lib/sellers.js
+++ b/lib/sellers.js
@@ -2,7 +2,6 @@ var Q = require('q');
 var restify = require('restify');
 var save = require('save');
 var under = require('underscore');
-var uuid = require('node-uuid');
 
 var models = exports.models = save('sellers');
 var forms = require('./restforms');
@@ -10,13 +9,13 @@ var fields = forms.fields;
 var z = require('./zutil');
 
 
-function withSeller(id, next, cb) {
-  if (!id) {
-    return next(new restify.InvalidArgumentError('ID must be supplied.'));
+function withSeller(uuid, next, cb) {
+  if (!uuid) {
+    return next(new restify.InvalidArgumentError('UUID must be supplied.'));
   }
-  models.findOne({_id: id}, function (err, seller) {
+  models.findOne({_id: uuid}, function (err, seller) {
     if (!seller) {
-      var error = z.markSafe('Resource with ID "' + z.escape(id) + '" cannot be found.');
+      var error = z.markSafe('Resource with UUID "' + z.escape(uuid) + '" cannot be found.');
       return next(new restify.ResourceNotFoundError({message: error}));
     }
     cb(err, seller);
@@ -35,7 +34,7 @@ exports.list = function(req, res, next) {
 
 exports.retrieve = function(req, res, next) {
   res.docName = 'seller';
-  withSeller(req.params.id, next, function (err, seller) {
+  withSeller(req.params.uuid, next, function (err, seller) {
     res.send(z.serialize(seller, 'sellers'));
   });
   next();
@@ -44,7 +43,7 @@ exports.retrieve = function(req, res, next) {
 
 exports.terms = function(req, res, next) {
   res.docName = 'sellerTerms';
-  withSeller(req.params.id, next, function (err, seller) {
+  withSeller(req.params.uuid, next, function (err, seller) {
     res.send({
       // This is a placeholder for real terms of services.
       text: 'Terms for seller: ' + seller.name,
@@ -59,13 +58,13 @@ var sellerForm = forms.create({
   uuid: fields.string({
     required: true,
     validators: [function(form, field, callback) {
-      models.findOne({uuid: field.data}, function(err, seller) {
+      models.findOne({_id: field.data}, function(err, seller) {
         if (err) {
           callback(err);
         } else if (!seller) {
           callback();  // uuid is unique, all good.
         } else {
-          callback('uuid must be unique');
+          callback('UUID must be unique');
         }
       });
     }],
@@ -90,7 +89,9 @@ var sellerForm = forms.create({
 exports.create = function(req, res, next) {
   sellerForm.promise(req)
     .then(function(data) {
-      data._id = uuid.v4();
+      // The UUID is stored internally as _id to ease "save" integration.
+      data._id = data.uuid;
+      delete data.uuid;
       return Q.ninvoke(models, 'create' , data);
     })
     .then(function(seller) {
@@ -101,8 +102,9 @@ exports.create = function(req, res, next) {
 
 
 exports.update = function(req, res, next) {
-  withSeller(req.params.id, next, function (err, seller) {
+  withSeller(req.params.uuid, next, function (err, seller) {
     // TODO(davidbgk): validate data with the sellerForm.
+    delete req.params.uuid;
     models.update(under.extend(seller, req.params), function (err, seller) {
       if (err) {
         return next(new restify.InvalidArgumentError(JSON.stringify(err.errors)));
@@ -115,7 +117,7 @@ exports.update = function(req, res, next) {
 
 
 exports.delete = function(req, res, next) {
-  withSeller(req.params.id, next, function (err, seller) {
+  withSeller(req.params.uuid, next, function (err, seller) {
     models.delete(seller._id, function (err) {
       if (err) {
         return next(new restify.InvalidArgumentError(JSON.stringify(err.errors)));

--- a/lib/server.js
+++ b/lib/server.js
@@ -96,10 +96,10 @@ function createServer(options) {
   server.post('/products', products.create);
   server.get('/sellers', sellers.list);
   server.post('/sellers', sellers.create);
-  server.get('/sellers/:id', sellers.retrieve);
-  server.put('/sellers/:id', sellers.update);
-  server.del('/sellers/:id', sellers.delete);
-  server.get('/terms/:id', sellers.terms);
+  server.get('/sellers/:uuid', sellers.retrieve);
+  server.put('/sellers/:uuid', sellers.update);
+  server.del('/sellers/:uuid', sellers.delete);
+  server.get('/terms/:uuid', sellers.terms);
   server.get('/styleguide/:doc', styleguide.retrieve);
   server.get('/styleguide', styleguide.retrieve);
   server.post('/transactions', trans.create);

--- a/test/suite/sellers.test.js
+++ b/test/suite/sellers.test.js
@@ -10,7 +10,7 @@ var client = new Client('/sellers');
 function withSeller(t, cb, opt) {
   opt = opt || {};
   var props = under.extend({
-    uuid: uuid.v4(),
+    _id: uuid.v4(),
     status: 'ACTIVE',
     name: 'John',
     email: 'jdoe@example.org',
@@ -29,11 +29,11 @@ exports.setUp = function(done) {
 
 exports.createSeller = function(t) {
   var seller = {
-    uuid: uuid.v4(),
+    _id: uuid.v4(),
   };
   client
     .post({
-      uuid: seller.uuid,
+      uuid: seller._id,
       status: 'ACTIVE',
       name: 'John',
       email: 'jdoe@example.org',
@@ -41,16 +41,19 @@ exports.createSeller = function(t) {
     .expect(201)
     .end(function(err, res) {
       t.ifError(err);
-      t.equal(res.body.uuid, seller.uuid);
+      t.equal(res.body.resource_pk, seller._id);
       t.done();
     });
 };
 
 
 exports.createSellerWithoutStatus = function(t) {
+  var seller = {
+    _id: uuid.v4(),
+  };
   client
     .post({
-      uuid: uuid.v4(),
+      uuid: seller._id,
       name: 'John',
       email: 'jdoe@example.org',
     })
@@ -70,7 +73,7 @@ exports.retrieveSellers = function(t) {
       .expect(200)
       .end(function(err, res) {
         t.ifError(err);
-        t.equal(res.body[0].uuid, seller.uuid);
+        t.equal(res.body[0].resource_pk, seller._id);
         t.done();
       });
   });
@@ -97,7 +100,7 @@ exports.retrieveSeller = function(t) {
       .expect(200)
       .end(function(err, res) {
         t.ifError(err);
-        t.equal(res.body.uuid, seller.uuid);
+        t.equal(res.body.resource_pk, seller._id);
         t.equal(res.body.resource_name, 'sellers');
         t.done();
       });
@@ -111,7 +114,7 @@ exports.updateSellerThenGet = function(t) {
     var updatedName = 'Jack';
     client
       .put({
-        uuid: seller.uuid,
+        uuid: seller._id,
         status: seller.status,
         name: updatedName,
         email: seller.email,
@@ -119,7 +122,7 @@ exports.updateSellerThenGet = function(t) {
       .expect(200)
       .end(function(err, res) {
         t.ifError(err);
-        t.equal(res.body.uuid, seller.uuid);
+        t.equal(res.body.resource_pk, seller._id);
         t.equal(res.body.name, updatedName);
         t.equal(res.body.email, seller.email);
         t.equal(res.body.resource_uri, '/sellers/' + res.body.resource_pk);
@@ -128,7 +131,7 @@ exports.updateSellerThenGet = function(t) {
           .expect(200)
           .end(function(err, res) {
             t.ifError(err);
-            t.equal(res.body.uuid, seller.uuid);
+            t.equal(res.body.resource_pk, seller._id);
             t.equal(res.body.name, updatedName);
             t.equal(res.body.email, seller.email);
             t.equal(res.body.resource_uri, '/sellers/' + res.body.resource_pk);
@@ -145,13 +148,13 @@ exports.updateSellerWithoutStatus = function(t) {
     var updatedName = 'Jack';
     client
       .put({
-        uuid: seller.uuid,
+        uuid: seller._id,
         name: updatedName,
       })
       .expect(200)
       .end(function(err, res) {
         t.ifError(err);
-        t.equal(res.body.uuid, seller.uuid);
+        t.equal(res.body.resource_pk, seller._id);
         t.equal(res.body.name, updatedName);
         t.equal(res.body.status, seller.status);
         t.done();
@@ -200,7 +203,7 @@ exports.updateSellerTerms = function(t) {
       .expect(200)
       .end(function(err, res) {
         t.ifError(err);
-        t.equal(res.body.uuid, seller.uuid);
+        t.equal(res.body.resource_pk, seller._id);
         t.equal(Date(res.body.agreement), currentDate);
         client = new Client('/terms/' + seller._id);
         client
@@ -215,5 +218,3 @@ exports.updateSellerTerms = function(t) {
       });
   });
 };
-
-


### PR DESCRIPTION
The UUID is stored internally as `_id` and returned serialized as `resource_pk`
