### PR TITLE
Bump zippy version for dep checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zippy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "A reference implementation for payment providers for the Firefox Marketplace.",
   "main": "main.js",


### PR DESCRIPTION
This should fix the dep-check images so they reflect the updated state of reality.
