### PR TITLE
Add docs for config and allow and check keys not in default

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,46 @@
+Zippy Config
+============
+
+Config works by overlaying additional rules on top of the base set.
+
+Keys are looked up when you ask for them using a getter and values are
+provided based on the following criteria:
+
+1. If `NODE_ENV` is not 'test' use local config value if that key exists.
+2. Use key in `NODE_ENV` config if it exists and has been setup in `config/index.js`.
+3. Use key in defaults.js
+
+Local overrides are possible unless the `NODE_ENV` environment is test
+
+Adding a new config
+-------------------
+
+To add a new config e.g: 'edge' create a new config file in lib/config called 'edge.js'
+
+In it define the keys you want to override. Totally new keys are allowed but you'll get
+a warning if it doesn't exist in the defaults conf.
+
+e.g::
+
+    module.exports = {
+        showClientConsole: true,
+    };
+
+Lastly update lib/config/index.js to add the require the new file adding it to the
+overall config object.
+
+e.g::
+    config.edge = require('./edge');
+
+.. note::
+    If you're adding something that shouldn't be committed to the repo then you'll want a
+    try/catch around the require see how the local file is required for an example.
+    (Now would be a good time to add it to .gitignore!).
+
+Using the config
+----------------
+
+Using the config is just a case of setting the `NODE_ENV` environment var before
+starting up the app. E.g::
+
+    NODE_ENV=test nodejs main.js

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,6 +103,7 @@ Contents
    developer.rst
    l10n.rst
    payment.rst
+   config.rst
    reporting.rst
    refunds.rst
    security.rst

--- a/lib/configobj.js
+++ b/lib/configobj.js
@@ -1,3 +1,5 @@
+var _ = require('underscore');
+
 function getNodeEnv() {
   var env;
   if (typeof process !== 'undefined' && process.env) {
@@ -11,21 +13,37 @@ function getNodeEnv() {
 }
 
 module.exports = function Config(config) {
+  var that = this;
+
   if (!config.default) {
     throw new Error("Default key of config object doesn't exist. Aborting.");
   }
-  var that = this;
 
-  Object.keys(config.default).forEach(function(key) {
+  // Get the keys from all the configs. This way we can add a config option
+  // that only exists in an overlayed config.
+  var listOfKeyLists = [];
+  Object.keys(config).forEach(function(key) {
+    listOfKeyLists.push(Object.keys(config[key]));
+  });
+
+  var keys = _.union.apply(this, listOfKeyLists);
+
+  keys.forEach(function(key) {
     that.__defineGetter__(key, function(){
       var env = getNodeEnv();
       if (env === 'local') {
         throw new Error('Pointless NODE_ENV. Local env is always overlayed unless the NODE_ENV is test');
       }
+
+      if (typeof config.default[key] === 'undefined') {
+        console.warn('[Warning] Config key "' + key + '" is not defined in the default config');
+      }
+
       // Define test config up front so we don't overlay local settings.
       if (env === 'test' && config.test && config.test[key]) {
         return config.test[key];
       }
+
       // local overrides everything that's not a test config.
       if (env !== 'test') {
         if (config.local && config.local[key]) {

--- a/test/suite/configobj.test.js
+++ b/test/suite/configobj.test.js
@@ -15,6 +15,7 @@ var exampleConfig = new Config({
   },
   prod: {
     bar: 'prod-bar',
+    onlyprod: 'onlyprod-foo',
   },
   test: {
     bar: 'test-bar',
@@ -66,5 +67,11 @@ exports.testDefaultFallThrough = function(t) {
 exports.testDoesntExist = function(t) {
   process.env.NODE_ENV = 'prod';
   t.equal(exampleConfig.whatever, undefined);
+  t.done();
+};
+
+exports.testDoesntExistInDefault = function(t) {
+  process.env.NODE_ENV = 'prod';
+  t.equal(exampleConfig.onlyprod, 'onlyprod-foo');
   t.done();
 };


### PR DESCRIPTION
Add the missing docs which explains how config works and how to add a new file to it.

Whilst doing this I thought it was annoying we couldn't have conf that exists only in an overlaid conf file so I added the ability to do that and it will warn if the key doesn't exist in the default conf file.
