### PR TITLE
Fix l10n display issues

### DIFF
--- a/media/stylus/_forms.styl
+++ b/media/stylus/_forms.styl
@@ -29,9 +29,14 @@ label {
     }
 }
 
-form label:first-of-type {
-    //margin-top: 0;
+html[dir="rtl"] label {
+    padding-left: 5px;
+
+    &:after {
+        padding-right: 0;
+    }
 }
+
 
 input,
 textarea {
@@ -43,6 +48,7 @@ textarea {
     width: 100%;
 
     &[type="checkbox"] {
+        flex(0);
         display: inline-block;
         width: auto;
         &:focus,
@@ -91,7 +97,8 @@ select {
         flex(1, 1, 50%);
         flex-direction(column);
         margin-bottom: 10px;
-        width: 1000em; /* hack so older flex implementations don't trash width */
+        width: 1em; /* hack so older flex implementations don't trash width */
+
         &:first-child {
             margin-right: 10px;
         }
@@ -121,6 +128,7 @@ select {
             &[type="checkbox"] {
                 min-width: auto;
                 margin-left: 5px;
+                flex(0, 0, auto);
             }
         }
 
@@ -129,7 +137,27 @@ select {
         }
 
     }
+
 }
+
+html[dir="rtl"] .flex {
+    label {
+        margin-left: 5px;
+        text-align: left;
+        min-width: 0;
+        padding-left: 0;
+
+        &:after {
+            padding-right: 0;
+            padding-left: 5px;
+        }
+    }
+    input[type="checkbox"] {
+        margin-left: 0;
+        margin-right: 5px;
+    }
+}
+
 
 @media $small-min-width {
 

--- a/media/stylus/inc/mixins.styl
+++ b/media/stylus/inc/mixins.styl
@@ -1,4 +1,5 @@
 box-sizing($val) {
+    -webkit-box-sizing: $val; // Needed for phantomjs.
     -moz-box-sizing: $val;
     box-sizing: $val;
 }

--- a/media/stylus/zippy.styl
+++ b/media/stylus/zippy.styl
@@ -89,18 +89,37 @@ main {
     }
 }
 
-.product-image {
-    display: inline-block;
-    margin-bottom: 20px;
-    max-width: 33.3333%;
-    vertical-align: top;
-    padding-right: 10px;
- }
+html[dir="rtl"] .button {
+    &:first-child {
+        margin-left: 5px
+        margin-right: 0;
+    }
+    &:only-child {
+        margin: 0;
+    }
+}
+
 
 .product {
-    display: inline-block;
-    max-width: 64%;
-    max-width: calc(66.6666% - 10px);
+    word-spacing: -4px; // nuke whitespace;
+
+    .image {
+        display: inline-block;
+        width: 25%;
+        vertical-align: top;
+        padding: 0 10px 10px 0;
+        img {
+            display: inline-block;
+            max-width: 100%;
+        }
+    }
+
+    .meta {
+        word-spacing: 0; // restore word-spacing.
+        display: inline-block;
+        width: 75%;
+        vertical-align: top;
+    }
 
     .author {
         margin-top: 0;
@@ -138,6 +157,7 @@ main {
         word-wrap: break-word;
     }
 }
+
 
 .payment-info {
     clear: left;

--- a/templates/payments/_product.html
+++ b/templates/payments/_product.html
@@ -1,10 +1,12 @@
-  <div class="grid">
+  <div class="product">
+    <div class="image">
     {% if trans.product_image_url %}
-      <img class="product-image" src="{{ trans.product_image_url }}" alt="Logo" />
+      <img src="{{ trans.product_image_url }}" alt="Logo" />
     {% else %}
-      <img class="product-image" src="/images/placeholder/logo.png" alt="Logo" />
+      <img src="/images/placeholder/logo.png" alt="Logo" />
     {% endif %}
-    <section class="product">
+    </div>
+    <section class="meta">
       <h2 class="title">{{ product.name }}</h2>
       <p class="author">{{ seller.name }}</p>
       <p class="total">{{ gettext('Total') }} ({{ trans.currency }}): <span class="price">{{ trans.price }}</span><a class="ref" href="#ref">*</a></p>

--- a/templates/payments/credit-card.html
+++ b/templates/payments/credit-card.html
@@ -39,7 +39,8 @@
         </div>
 
         <div class="flex checkbox">
-          <label class="no-wrap right save-card" for="save-card">{{ gettext('Save card') }}<input type="checkbox" value="1" name="save-card" id="save-card" /></label>
+          <label class="no-wrap right save-card" for="save-card">{{ gettext('Save card') }}</label>
+          <input class="right" type="checkbox" value="1" name="save-card" id="save-card" />
         </div>
 
       </div>

--- a/uitest/suite/test.product-text-wrap.js
+++ b/uitest/suite/test.product-text-wrap.js
@@ -9,24 +9,31 @@ startCasper('/payment/confirm');
 casper.test.begin('Product Text Wrapping', {
 
   test: function(test) {
-    casper.waitForSelector('.product-image', function() {
+
+    casper.waitForSelector('.product .image', function() {
       // Run the tests.
-      var dataObj = casper.evaluate(function(){
+      casper.evaluate(function(){
         // Tell jshint we know $ is a global.
         /* globals $ */
         var LONG_PROD_STRING = 'Test AP (fkjsdhkfjhsdkjfhsdkjhfksdjhkjfdsh)';
-        var LONG_AUTHOR_STRING = 'Some-really-long-string-that-shouldn\'t break this';
+        var LONG_AUTHOR_STRING = 'some-really-long-string-that-shouldn\'t break this';
         // Inject some long strings.
         $('.product .title').text(LONG_PROD_STRING);
         $('.product .author').text(LONG_AUTHOR_STRING);
-
-        var data = {};
-        data.image_offset =  $('.product-image').offset().top;
-        data.product_offset = $('.product').offset().top;
-        return data;
       });
 
+    });
+
+    casper.waitForSelectorTextChange('.product .title', function() {
+      var dataObj = casper.evaluate(function(){
+        return {
+          product_offset: $('.product .meta').offset().top,
+          image_offset: $('.product .image').offset().top,
+        };
+      });
       test.assertEqual(dataObj.product_offset, dataObj.image_offset, 'Check image and product tops are aligned (e.g: not wrapped)');
+      var file = 'uitest/captures/wrapping.png';
+      casper.capture(file);
     });
 
     casper.run(function() {


### PR DESCRIPTION
Some small fix-ups for l10n so that things are accessible/readable. 

Main issue was checkbox was gone with truncated string because it was inside the label. This moves it out.
Secondly there were some small rtl issues.

Some long strings are still truncated assuming the trusted-ui width of 275x346 (I made a page to report the trusted-ui width so we are actually dealing with the correct width (that's with an inari on b2g 1.2)) so we might need to consider dropping text size programmatically to accommodate it if we want to avoid an ellipsis (desirable).
