### PR TITLE
Fix paths for docker

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -178,26 +178,20 @@ module.exports = function(grunt) {
     grunt.fail.fatal('There is no "server" command use grunt start instead');
   });
 
-  // Workaround having node_modules in parent dir for Docker.
-  var cwd;
   if (process.env.IS_DOCKER) {
-    cwd = process.cwd();
-    process.chdir(__dirname);
-  }
-
-  grunt.loadNpmTasks('grunt-bower-task');
-  grunt.loadNpmTasks('grunt-casper');
-  grunt.loadNpmTasks('grunt-concurrent');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-stylus');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-i18n-abide');
-  grunt.loadNpmTasks('grunt-nodemon');
-  grunt.loadNpmTasks('grunt-shell');
-
-  if (cwd && process.env.IS_DOCKER) {
-    process.chdir(cwd);
+    // Workaround having node_modules in parent dir for Docker.
+    grunt.file.expand('../node_modules/grunt-*/tasks').forEach(grunt.loadTasks);
+  } else {
+    grunt.loadNpmTasks('grunt-bower-task');
+    grunt.loadNpmTasks('grunt-casper');
+    grunt.loadNpmTasks('grunt-concurrent');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-stylus');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-i18n-abide');
+    grunt.loadNpmTasks('grunt-nodemon');
+    grunt.loadNpmTasks('grunt-shell');
   }
 
   grunt.registerTask('default', ['jshint', 'stylus']);

--- a/lib/server.js
+++ b/lib/server.js
@@ -42,7 +42,7 @@ function createApp(options) {
     debug_lang: 'db-LB',
     default_lang: 'en-US',
     locale_on_url: true,
-    translation_directory: 'i18n'
+    translation_directory: path.join(z.rootPath, 'i18n')
   }));
 
   if (config.logging) {


### PR DESCRIPTION
Fix the way paths are handled for docker. This is due to the necessity of needing to have node_modules installed above the /srv/zippy/src so that we don't create any symlinks in the vbox-shared folders (as symlinks are disabled by default).
