### PR TITLE
Make Zippy work with Docker (bug 1046279)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@ FROM mozillamarketplace/centos-phantomjs-mkt:0.1
 
 ENV IS_DOCKER 1
 
-RUN yum install -y gcc-c++
+# local redis needed for tests.
+RUN yum install -y gcc-c++ redis
 
 RUN mkdir -p /srv/zippy
 ADD package.json /srv/zippy/package.json
 
 WORKDIR /srv/zippy
+
+RUN npm cache clean
 RUN npm install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,9 +2,9 @@ var http = require('http');
 var config = require('./lib/config');
 
 module.exports = function(grunt) {
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-
     abideCreate: {
       default: { // Target name.
         options: {
@@ -53,9 +53,9 @@ module.exports = function(grunt) {
         options: {
           args: ['-p', grunt.option('port'),
                  grunt.option('noauth') ? '-n': ''],
-          ignore: ['README.md', 'node_modules/**', 'i18n/**'],
-          ext: 'js,html',
-          delayTime: 1,
+          ignore: ['README.md', 'node_modules/**', 'i18n/**', '../node_modules/**'],
+          ext: 'js, html',
+          delay: 5000,
           legacyWatch: false,
           cwd: __dirname,
         }
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
       dev: {
         tasks: ['nodemon:server', 'watch'],
         options: {
-          logConcurrentOutput: true,
+          logConcurrentOutput: false,
         }
       },
     },
@@ -194,12 +194,13 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-i18n-abide');
     grunt.loadNpmTasks('grunt-nodemon');
+    grunt.loadNpmTasks('grunt-services');
     grunt.loadNpmTasks('grunt-shell');
   }
 
   grunt.registerTask('default', ['jshint', 'stylus']);
   grunt.registerTask('docs', ['shell:docs']);
   grunt.registerTask('start', ['stylus', 'concurrent:dev']);
-  grunt.registerTask('test', ['jshint', 'runtests']);
+  grunt.registerTask('test', ['startRedis', 'jshint', 'runtests']);
   grunt.registerTask('uitest', ['stylus', 'clean:uitest', 'runuitests']);
 };

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -13,6 +13,9 @@ function getEnvVar(key) {
 
 
 module.exports = {
+
+  basePath: '/',
+
   // These are active secret keys to create signatures with.
   // Make sure they are really long and random strings.
   // To rotate keys, add a new key with an index one greater

--- a/lib/config/docker.js
+++ b/lib/config/docker.js
@@ -1,0 +1,7 @@
+module.exports = {
+  basePath: '/zippy/',
+  redisConn: {
+    host: 'redis',
+    port: 6379,
+  },
+};

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -19,4 +19,16 @@ try {
   console.warn('Created a local config file at ', dest,
                '; update it with real values.');
 }
+
+// Import the docker config if this is running under docker.
+if (typeof process !== 'undefined' && process.env.IS_DOCKER) {
+  try {
+    config.docker = require('./docker');
+  } catch (err) {
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err;
+    }
+  }
+}
+
 module.exports = new Config(config);

--- a/lib/configobj.js
+++ b/lib/configobj.js
@@ -44,6 +44,12 @@ module.exports = function Config(config) {
         return config.test[key];
       }
 
+      // Overlay docker conf which is only present if we're running
+      // under docker.
+      if (config.docker && config.docker[key]) {
+        return config.docker[key];
+      }
+
       // local overrides everything that's not a test config.
       if (env !== 'test') {
         if (config.local && config.local[key]) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,8 @@ var i18n = require('i18n-abide');
 var nunjucks = require('nunjucks');
 var passport = require('passport');
 var path = require('path');
-var sessions = require("client-sessions");
+var sessions = require('client-sessions');
+var url = require('url');
 
 require('./httperrors');
 
@@ -35,6 +36,14 @@ function createApp(options) {
   app.set('name', 'zippy');
   app.set('trust proxy', true);
 
+  if (process.env.IS_DOCKER) {
+    var rewriteModule = require('http-rewrite-middleware');
+    app.use(rewriteModule.getMiddleware([
+      // Internally redirect urls to be handled by the client-side spa serving view.
+      {from: '^/zippy/(.*)$', to: '/$1'},
+    ]));
+  }
+
   // Needs to be first so that the lang code in urls works.
   app.use(i18n.abide({
     /*jshint camelcase: false */
@@ -44,6 +53,7 @@ function createApp(options) {
     locale_on_url: true,
     translation_directory: path.join(z.rootPath, 'i18n')
   }));
+
 
   if (config.logging) {
     app.use(express.logger({format: config.logging.format}));
@@ -73,7 +83,15 @@ function createApp(options) {
   }
 
   var env = new nunjucks.Environment(new nunjucks.FileSystemLoader(templatePaths),
-                                     { autoescape: true });
+                                     { autoescape: true, watch: false });
+
+  env.addGlobal('url', function(path) {
+    if (path === '/') {
+      return config.basePath || '/';
+    }
+    return url.resolve(config.basePath, path);
+  });
+
   env.express(app);
 
   app.use(sessions({

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "escape-html": "1.0.1",
     "express": "3.4.8",
     "forms": "0.9.6",
+    "http-rewrite-middleware": "0.1.6",
     "i18n-abide": "0.0.22",
     "node-uuid": "1.4.1",
     "nunjucks": "1.0.7",
@@ -18,10 +19,10 @@
     "passport-http-oauth": "0.1.3",
     "posix-getopt": "1.1.0",
     "q": "1.0.1",
-    "save": "0.0.20",
-    "underscore": "1.7.0",
     "request": "2.42.0",
+    "save": "0.0.20",
     "then-redis": "~0.3.9",
+    "underscore": "1.7.0",
     "when": "3.4.5"
   },
   "devDependencies": {
@@ -35,6 +36,7 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-i18n-abide": "0.0.12",
     "grunt-nodemon": "0.3.0",
+    "grunt-services": "0.0.2",
     "grunt-shell": "1.1.1",
     "nock": "0.46.0",
     "nodeunit": "0.9.0",

--- a/templates/base-docs.html
+++ b/templates/base-docs.html
@@ -11,7 +11,7 @@
 <nav>
   <ul>
     <li><a href="https://zippypayments.readthedocs.org/en/latest/">API Documentation</a></li>
-    <li><a href="/styleguide/">Styleguide</a></li>
+    <li><a href="{{ url('styleguide/') }}">Styleguide</a></li>
   </ul>
 </nav>
 {% endblock %}
@@ -22,4 +22,4 @@
   <pre>{{ result }}</pre>
 {% endblock %}
 
-{% block footer %}<p><a href="/">← Back to home</a></p>{% endblock %}
+{% block footer %}<p><a href="{{ url('/') }}">← Back to home</a></p>{% endblock %}

--- a/templates/base-payments.html
+++ b/templates/base-payments.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
 {% block style %}
-<link rel="stylesheet" href="/css/zippy.css">
+<link rel="stylesheet" href="{{ url('css/zippy.css') }}">
 {% endblock %}
 
 {% block script %}
-<script data-main="/js/main.js" src="/lib/js/requirejs/require.js"></script>
+<script data-main="{{ url('js/main.js') }}" src="{{ url('lib/js/requirejs/require.js') }}"></script>
 {% endblock %}

--- a/templates/base-styleguide.html
+++ b/templates/base-styleguide.html
@@ -3,10 +3,10 @@
 {% block bodyattrs %} class="styleguide"{% endblock %}
 
 {% block style %}
-<link rel="stylesheet" href="/css/styleguide.css">
-<link rel="stylesheet" href="/css/zippy.css">
+<link rel="stylesheet" href="{{ url('css/styleguide.css') }}">
+<link rel="stylesheet" href="{{ url('css/zippy.css') }}">
 {% endblock %}
 
 {% block script %}
-<script data-main="/js/styleguide/main.js" src="/lib/js/requirejs/require.js"></script>
+<script data-main="{{ url('js/styleguide/main.js') }}" src="{{ url('lib/js/requirejs/require.js') }}"></script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
   <title>{% block title %}{{ title }}{% endblock %}</title>
-  {% block style %}<link rel="stylesheet" href="/css/docs.css">{% endblock %}
+  {% block style %}<link rel="stylesheet" href="{{ url('css/docs.css') }}">{% endblock %}
 </head>
 <body{% block bodyattrs %}{% endblock %}>
   <div class="page">

--- a/templates/error.html
+++ b/templates/error.html
@@ -4,7 +4,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block style %}
-<link rel="stylesheet" href="/css/zippy.css">
+<link rel="stylesheet" href="{{ url('css/zippy.css') }}">
 {% endblock %}
 
 {% block main %}

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -5,7 +5,7 @@
   <h2>This is a reference implementation of a payment processor.</h2>
   <p>
     You can <a href="http://zippypayments.readthedocs.org/en/latest/">browse the documentation</a>,
-    <a href="/styleguide/">view the styleguide</a>
-    or <a href="/payment/start">start a payment</a>.
+    <a href="{{ url('styleguide/') }}">view the styleguide</a>
+    or <a href="{{ url('payment/start') }}">start a payment</a>.
   </p>
 {% endblock %}

--- a/templates/styleguide/buttons.html
+++ b/templates/styleguide/buttons.html
@@ -18,5 +18,5 @@
   <a href="#"  class="button cta">Call To Action (.cta)</a>
   <a href="#" class="button cta" disabled>Call To Action (.cta) (disabled)</a>
 
-  <p>See also <a href="two-buttons">Two Buttons (Button elements)</a> and <a href="two-buttons-link">Two Buttons (Links)</a>for how to group buttons in the footer.</p>
+  <p>See also <a href="two-buttons">Two Buttons (Button elements)</a> and <a href="two-buttons-link">Two Buttons (Links)</a> for how to group buttons in the footer.</p>
 {% endblock %}

--- a/templates/styleguide/index.html
+++ b/templates/styleguide/index.html
@@ -16,7 +16,7 @@
   <ul>
   {% for doc in docList %}
     {% if doc != 'index' %}
-      <li><a href="/styleguide/{{ doc }}" />{{ doc|title }}</a></li>
+      <li><a href="{{ url('styleguide/') }}{{ doc }}" />{{ doc|title }}</a></li>
     {% endif %}
   {% endfor %}
   </ul>


### PR DESCRIPTION
This allows us to use a different path for zippy so under docker http://mp.dev/zippy/ is zippy's homepage.

Anything to /zippy/\* is rewritten to /\* internally by the node app. 
