### PR TITLE
start on 2605 by default and expose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,5 @@ WORKDIR /srv/zippy
 
 RUN npm cache clean
 RUN npm install
+
+EXPOSE 2605

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
       dev: {
         tasks: ['nodemon:server', 'watch'],
         options: {
-          logConcurrentOutput: false,
+          logConcurrentOutput: true,
         }
       },
     },

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ function main(options) {
   var server = http.createServer(zippy.createApp({
     options: options,
   }));
-  var port = options.port || 8080;
+  var port = options.port || 2605;
   server.listen(port, function onServerStart() {
     var addr = this.address();
     console.log('listening at %s:%s', addr.address, addr.port);


### PR DESCRIPTION
- go to 2605 by default, not 8080, in-case zippy does a restart
- log what zippy is doing so you can see
- expose 2605 so others can see it
