### PR TITLE
Upgrade to express 4

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,12 @@
+var bodyParser = require('body-parser');
 var errors = require('errors');
 var express = require('express');
 var i18n = require('i18n-abide');
+var morgan = require('morgan');
 var nunjucks = require('nunjucks');
 var passport = require('passport');
 var path = require('path');
+var serveStatic = require('serve-static');
 var sessions = require('client-sessions');
 var url = require('url');
 
@@ -56,7 +59,7 @@ function createApp(options) {
 
 
   if (config.logging) {
-    app.use(express.logger({format: config.logging.format}));
+    app.use(morgan({format: config.logging.format}));
   }
 
   if (!options.options || !options.options.noAuth) {
@@ -101,8 +104,8 @@ function createApp(options) {
   }));
 
   // Parse JSON or urlencoded POST data but not file uploads.
-  app.use(express.json());
-  app.use(express.urlencoded());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({extended: false}));
 
   // Warning: some of these URLs below returns list of objects (products, sellers)
   // that can be used for JSON Hijacking as documented here:
@@ -137,7 +140,7 @@ function createApp(options) {
   app.get('/payment/confirm-pin', payment.confirmSMSPin);
 
   // Static Resources.
-  app.get(/\/(?:css|fonts|images|js|lib)\/?.*/, express.static('./media'));
+  app.get(/\/(?:css|fonts|images|js|lib)\/?.*/, serveStatic('./media'));
 
   // 404 Catch-all.
   app.use(function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "client-sessions": "0.6.0",
     "errors": "0.2.0",
     "escape-html": "1.0.1",
-    "express": "3.4.8",
+    "express": "4.12.3",
     "forms": "0.9.6",
     "http-rewrite-middleware": "0.1.6",
     "i18n-abide": "0.0.22",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "A reference implementation for payment providers for the Firefox Marketplace.",
   "main": "main.js",
   "dependencies": {
+    "body-parser": "^1.12.3",
     "client-sessions": "0.6.0",
     "errors": "0.2.0",
     "escape-html": "1.0.1",
@@ -12,6 +13,7 @@
     "forms": "0.9.6",
     "http-rewrite-middleware": "0.1.6",
     "i18n-abide": "0.0.22",
+    "morgan": "^1.5.2",
     "node-uuid": "1.4.1",
     "nunjucks": "1.0.7",
     "oauth-client": "0.3.0",
@@ -21,6 +23,7 @@
     "q": "1.0.1",
     "request": "2.42.0",
     "save": "0.0.20",
+    "serve-static": "^1.9.2",
     "then-redis": "~0.3.9",
     "underscore": "1.7.0",
     "when": "3.4.5"


### PR DESCRIPTION
Updates zippy to express 4 and use the new separate middleware packages.